### PR TITLE
Fix yazi entry in windows terminal post TOC

### DIFF
--- a/_posts/2025-10-16-windows-production-tools.md
+++ b/_posts/2025-10-16-windows-production-tools.md
@@ -34,6 +34,7 @@ The most exciting part after getting a new machine is configuration! In this pos
   - [bottom - Better top](#bottom---better-top)
   - [fzf - Fuzzy finder](#fzf---fuzzy-finder)
   - [zoxide - Smart cd](#zoxide---smart-cd)
+  - [yazi - TUI file manager](#yazi---tui-file-manager)
 - [Development Settings](#development-settings)
   - [lazygit - TUI for git commands](#lazygit---tui-for-git-commands)
   - [lazydocker - TUI for docker commands](#lazydocker---tui-for-docker-commands)


### PR DESCRIPTION
## Summary
- add the missing `yazi - TUI file manager` entry to the table of contents in the Windows terminal configuration post

## Validation
- not run; documentation-only change
